### PR TITLE
Added some more Metadata

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,15 +6,14 @@ A simple sensor for MyJDownloader state
 
 # Configuration
 
-```
+``` YAML
 sensor:
   - platform: myjdownloader
     email: myname@email.com
     password: mypassword
-    name: JDownloader@doudz
+    name: JDownloader@doudz # optional, if not provided all JDownloader devices will be generated.
+    scan_interval: 5 # optional - default is 60
 ```
 
-`name` is optionnal, if not provided it will generated as many as found JDownloader device.
-
-The name could be found on MyJDownloader web interface <https://my.jdownloader.org/index.html>
+The name can be found via the MyJDownloader web interface <https://my.jdownloader.org/index.html>
 

--- a/custom_components/myjdownloader/sensor.py
+++ b/custom_components/myjdownloader/sensor.py
@@ -81,7 +81,7 @@ class MyJDSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         return self._attributes
-        
+
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
@@ -104,7 +104,7 @@ class MyJDSensor(Entity):
             # get download information
             downloadList = device.downloads.query_links()
             currentDownloads = [x for x in downloadList if x['status'] == 'Download']
-            
+
             # get current speed information
             value = device.downloadcontroller.get_speed_in_bytes()
 
@@ -115,7 +115,7 @@ class MyJDSensor(Entity):
             self._attributes['status'] = device.downloadcontroller.get_current_state()
             self._attributes['download_list'] = downloadList
             self._attributes['current_downloads'] = currentDownloads
-            
+
         except myjdapi.myjdapi.MYJDException as e:
             e = str(e).strip()
             if e == 'Device not found':


### PR DESCRIPTION
As discussed here #3 

I switched the sensor value from the current state to the current speed to enable some more automations and put in the metadata as planned. There is a lot potential in the download list for infos like ETA / remaining MB / etc.. 

Heres an automation example possible by using current speed as value: 

``` yaml
- id: 'JD Running'
  alias: JD Download running
  description: ''
  trigger:
  - entity_id: sensor.jd_rpi4
    platform: state
  condition:
  - condition: template
    value_template: '{{ states.sensor.jd_rpi4.attributes.current_downloads | length != 0}}'
  action:
  - data:
      data:
        silent: true
        tag: jdownloader
      message: >
        {% for d in state_attr('sensor.jd_rpi4', 'current_downloads') %}

        ETA:{{d['eta']}}s {{d['speed'] | filesizeformat}}/s - {{d['name']}}

        {% endfor %}
      title: 📥 Download läuft 📥
    service: notify.broadcast
```