### PR TITLE
Ensure HA 2021.6 compatibility + change value to MB/s

### DIFF
--- a/custom_components/myjdownloader/manifest.json
+++ b/custom_components/myjdownloader/manifest.json
@@ -2,7 +2,7 @@
   "domain": "myjdownloader",
   "name": "MyJDownloader",
   "documentation": "https://www.home-assistant.io/integrations/myjdownloader",
-  "requirements": ["myjdapi==1.0.5"],
+  "requirements": ["myjdapi==1.0.6"],
   "dependencies": [],
   "codeowners": ["doudz"]
 }

--- a/custom_components/myjdownloader/manifest.json
+++ b/custom_components/myjdownloader/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/myjdownloader",
   "requirements": ["myjdapi==1.0.6"],
   "dependencies": [],
-  "codeowners": ["doudz"]
+  "codeowners": ["doudz"],
+  "version": 1.0
 }

--- a/custom_components/myjdownloader/sensor.py
+++ b/custom_components/myjdownloader/sensor.py
@@ -110,7 +110,7 @@ class MyJDSensor(Entity):
                 currentDownloads = [x for x in downloadList if not x.get('finished', False)]
 
             # get current speed information
-            value = device.downloadcontroller.get_speed_in_bytes() / 1_000_000
+            value = round(device.downloadcontroller.get_speed_in_bytes() / 1_000_000, 2)
 
             # get if there are updates available
             updates = device.update.is_update_available()

--- a/custom_components/myjdownloader/sensor.py
+++ b/custom_components/myjdownloader/sensor.py
@@ -87,7 +87,7 @@ class MyJDSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return "byte"
+        return "MB/s"
 
     def update(self):
         """Get the latest data and updates the state."""
@@ -110,7 +110,7 @@ class MyJDSensor(Entity):
                 currentDownloads = [x for x in downloadList if not x.get('finished', False)]
 
             # get current speed information
-            value = device.downloadcontroller.get_speed_in_bytes()
+            value = device.downloadcontroller.get_speed_in_bytes() / 1_000_000
 
             # get if there are updates available
             updates = device.update.is_update_available()


### PR DESCRIPTION
Hi there,

I added a version key to the manifest file so ensure that the integration works with 2021.6.
Additionally, I changed the unit to MB/s as I think it's more useful for the majority of the users.

Thanks!