### PR TITLE
Update device registry entry_type (fixes #20)

### DIFF
--- a/custom_components/myjdownloader/entities.py
+++ b/custom_components/myjdownloader/entities.py
@@ -7,6 +7,7 @@ from string import Template
 from myjdapi.exception import MYJDConnectionException
 
 from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.device_registry import DeviceEntryType
 
 from . import MyJDownloaderHub
 from .const import DOMAIN
@@ -110,7 +111,7 @@ class MyJDownloaderDeviceEntity(MyJDownloaderEntity):
             name=f"JDownloader {self._device_name}",
             manufacturer="AppWork GmbH",
             model=self._device_type,
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
         )
 
     async def async_update(self) -> None:


### PR DESCRIPTION
As of Home Assistant 2022.3, the device registry entry_type is no longer a string. This updates it to use the relevant DeviceEntryType const.

Fixes https://github.com/doudz/homeassistant-myjdownloader/issues/20