### PR TITLE
Set the correct device class for the update sensor

### DIFF
--- a/custom_components/myjdownloader/binary_sensor.py
+++ b/custom_components/myjdownloader/binary_sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import datetime
 
 from homeassistant.components.binary_sensor import (
-    DEVICE_CLASS_PROBLEM,
+    DEVICE_CLASS_UPDATE,
     DOMAIN,
     BinarySensorEntity,
 )
@@ -110,7 +110,7 @@ class MyJDownloaderUpdateAvailableSensor(MyJDownloaderBinarySensor):
             "JDownloader $device_name Update Available",
             None,
             "update_available",
-            DEVICE_CLASS_PROBLEM,
+            DEVICE_CLASS_UPDATE,
             ENTITY_CATEGORY_DIAGNOSTIC,
         )
 


### PR DESCRIPTION
The update sensor currently uses the "problem" device class, however there is a dedicated "update" device class for this purpose. This makes it consistent with other update sensors from other integrations - most obviously the state text displayed in the UI ("Update available" vs "Up-to-date") and standard update icons used.